### PR TITLE
Update RunPQSDKTestSuites.ps1

### DIFF
--- a/testframework/tests/RunPQSDKTestSuites.ps1
+++ b/testframework/tests/RunPQSDKTestSuites.ps1
@@ -3,7 +3,7 @@
        Script: RunPQSDKTestSuites.ps1
        Runs the pre-built PQ/PQOut format tests in Power Query SDK Test Framework using pqtest.exe compare command.
 
-       .DESCRIPTION
+      .DESCRIPTION
        This script will execute the PQ SDK PQ/PQOut tests present under Sanity, Standard & DataSourceSpecific folders. 
        RunPQSDKTestSuitesSettings.json file is used provide configurations need to this script. Please review the template RunPQSDKTestSuitesSettingsTemplate.json for more info.
        Pre-Requisite: Ensure the credentials are setup for your connector following the instructions here: https://learn.microsoft.com/power-query/power-query-sdk-vs-code#set-credential
@@ -50,57 +50,64 @@ param(
     [string[]]$TestSettingsList,
     [switch]$ValidateQueryFolding,
     [switch]$DetailedResults,
-    [switch]$JSONResults
+    [switch]$JSONResults,
+    [string]$RunPQSDKTestSuitesSettingsPath,
+    [switch]$Pipeline
 )
 
 # Pre-Requisite:   
 # Ensure the credentials are setup for your connector following the instructions here: https://learn.microsoft.com/en-us/power-query/power-query-sdk-vs-code#set-credential 
 
 # Retrieving the settings for running the TestSuites from the JSON settings file
-$RunPQSDKTestSuitesSettings = Get-Content -Path RunPQSDKTestSuitesSettings.json | ConvertFrom-Json
+if ($RunPQSDKTestSuitesSettingsPath) {
+    $RunPQSDKTestSuitesSettings = Get-Content -Path $RunPQSDKTestSuitesSettingsPath | ConvertFrom-Json
+}
 
 # Setting the PQTestExePath from settings object if not passed as an argument
-if (!$PQTestExePath){ $PQTestExePath = $RunPQSDKTestSuitesSettings.PQTestExePath }
-if (!(Test-Path -Path $PQTestExePath)){
-    Write-Output("PQTestExe path is not correctly set. Either set it in RunPQSDKTestSuitesSettings.json or pass it as an argument. " +  $PQTestExePath)
-    exit
+if (!$PQTestExePath) { $PQTestExePath = $RunPQSDKTestSuitesSettings.PQTestExePath }
+if ([string]::IsNullOrEmpty($PQTestExePath) -or !(Test-Path -Path $PQTestExePath)) {
+    #try to find the latest PQtest
+    $PQTestExePath = Get-ChildItem "$home\.vscode\extensions" -recurse -include "PQTest.exe" | Select-Object -last 1 | ForEach-Object { $_.FullName }
+    if ([string]::IsNullOrEmpty($PQTestExePath) -or !(Test-Path -Path $PQTestExePath)) {
+        Write-Output("PQTestExe path is not correctly set. Either set it in RunPQSDKTestSuitesSettings.json or pass it as an argument. " + $PQTestExePath)
+        exit
+    }
 }
 
 # Setting the ExtensionPath from settings object if not passed as an argument
-if (!$ExtensionPath){ $ExtensionPath = $RunPQSDKTestSuitesSettings.ExtensionPath }
-if (!(Test-Path -Path $ExtensionPath)){
+if (!$ExtensionPath) { $ExtensionPath = $RunPQSDKTestSuitesSettings.ExtensionPath }
+if ([string]::IsNullOrEmpty($ExtensionPath) -or !(Test-Path -Path $ExtensionPath)) {
     Write-Output("Extension path is not correctly set. Either set it in RunPQSDKTestSuitesSettings.json or pass it as an argument. " + $ExtensionPath)
     exit
 }
 
 # Setting the TestSettingsDirectoryPath if not passed as an argument
-if (!$TestSettingsDirectoryPath){
-    if ($RunPQSDKTestSuitesSettings.TestSettingsDirectoryPath){
+if (!$TestSettingsDirectoryPath) {
+    if ($RunPQSDKTestSuitesSettings.TestSettingsDirectoryPath) {
         $TestSettingsDirectoryPath = $RunPQSDKTestSuitesSettings.TestSettingsDirectoryPath
     }
-    else 
-    {
-        $GenericTestSettingsDirectoryPath  = Join-Path -Path (Get-Location) -ChildPath ("ConnectorConfigs\generic\Settings")
+    else {
+        $GenericTestSettingsDirectoryPath = Join-Path -Path (Get-Location) -ChildPath ("ConnectorConfigs\generic\Settings")
         $TestSettingsDirectoryPath = Join-Path -Path (Get-Location) -ChildPath ("ConnectorConfigs\" + (Get-Item $ExtensionPath).Basename + "\Settings")
 
         # Creating the test settings and parameter query file(s) automatically 
-        if (!(Test-Path $TestSettingsDirectoryPath)){
+        if (!(Test-Path $TestSettingsDirectoryPath)) {
             $PSStyle.Foreground.Blue
             Write-Output("Performing the initial setup by creating the test settings and parameter query file(s) automatically...");
             $PSStyle.Reset
             Copy-Item -Path $GenericTestSettingsDirectoryPath -Destination $TestSettingsDirectoryPath -Recurse
             Write-Output("Successfully created test settings file(s) under the directory:`n" + $TestSettingsDirectoryPath);
         }
-        $GenericParameterQueriesPath  = Join-Path -Path (Get-Location) -ChildPath ("ConnectorConfigs\generic\ParameterQueries")
+        $GenericParameterQueriesPath = Join-Path -Path (Get-Location) -ChildPath ("ConnectorConfigs\generic\ParameterQueries")
         $ExtensionParameterQueriesPath = Join-Path -Path (Get-Location) -ChildPath ("ConnectorConfigs\" + (Get-Item $ExtensionPath).Basename + "\ParameterQueries")
-        if (!(Test-Path $ExtensionParameterQueriesPath)){
+        if (!(Test-Path $ExtensionParameterQueriesPath)) {
             Copy-Item -Path $GenericParameterQueriesPath -Destination $ExtensionParameterQueriesPath -Recurse
-            Rename-Item -Path (Join-Path -Path $ExtensionParameterQueriesPath -ChildPath "Generic.parameterquery.pq")  -NewName ((Get-Item $ExtensionPath).Basename +".parameterquery.pq")
+            Rename-Item -Path (Join-Path -Path $ExtensionParameterQueriesPath -ChildPath "Generic.parameterquery.pq")  -NewName ((Get-Item $ExtensionPath).Basename + ".parameterquery.pq")
             Write-Output("Successfully created the parameter query file(s) under the directory:`n" + $ExtensionParameterQueriesPath);
             $PSStyle.Reset
 
             # Updating the parameter query file(s) location in the test setting file
-            foreach ($SettingsFile in (Get-ChildItem $TestSettingsDirectoryPath | ForEach-Object {$_.FullName})){
+            foreach ($SettingsFile in (Get-ChildItem $TestSettingsDirectoryPath | ForEach-Object { $_.FullName })) {
                 $SettingsFileJson = Get-Content -Path $SettingsFile | ConvertFrom-Json
                 $SettingsFileJson.ParameterQueryFilePath = $SettingsFileJson.ParameterQueryFilePath.ToLower().Replace("generic", (Get-Item $ExtensionPath).Basename)
                 $SettingsFileJson | ConvertTo-Json -depth 100 |  Set-Content $SettingsFile
@@ -111,8 +118,7 @@ if (!$TestSettingsDirectoryPath){
             $parameterQueryUpdated = Read-Host ("Please update the parameter query file(s) generated by replacing with the M query to connect to your data source and retrieve the NycTaxiGreen & TaxiZoneLookup tables.`nAre File(s) updated? [y/n]")
             $PSStyle.Reset
 
-            while($parameterQueryUpdated -ne "y")
-            {
+            while ($parameterQueryUpdated -ne "y") {
                 if ($parameterQueryUpdated -eq 'n') {
                     $PSStyle.Foreground.Red
                     Write-Host("Please update the parameter query file(s) generated by replacing with the M query to connect to your data source and retrieve the NycTaxiGreen & TaxiZoneLookup tables and rerun the script.")
@@ -123,10 +129,10 @@ if (!$TestSettingsDirectoryPath){
                 $parameterQueryUpdated = Read-Host "Please update the parameter query file(s) generated by replacing with the M query to connect to your data source and retrieve the NycTaxiGreen & TaxiZoneLookup tables.`nAre File(s) updated? [y/n]"
                 $PSStyle.Reset
             }
-    }
-} 
+        }
+    } 
 }
-if (!(Test-Path -Path $TestSettingsDirectoryPath)){ 
+if (!(Test-Path -Path $TestSettingsDirectoryPath)) { 
     Write-Output("Test Settings Directory is not correctly set. Either set it in RunPQSDKTestSuitesSettings.json or pass it as an argument. " + $TestSettingsDirectoryPath)
     exit
 }
@@ -134,32 +140,32 @@ if (!(Test-Path -Path $TestSettingsDirectoryPath)){
 
 #Setting the TestSettingsList if not passed as an argument
 
-if (!$TestSettingsList){
-    if ($RunPQSDKTestSuitesSettings.TestSettingsList){
+if (!$TestSettingsList) {
+    if ($RunPQSDKTestSuitesSettings.TestSettingsList) {
         $TestSettingsList = $RunPQSDKTestSuitesSettings.TestSettingsList
     }
-    else{
-    $TestSettingsList = (Get-ChildItem -Path $TestSettingsDirectoryPath -Name)
+    else {
+        $TestSettingsList = (Get-ChildItem -Path $TestSettingsDirectoryPath -Name)
     }
 }
 
 #Setting the ValidateQueryFolding if not passed as an argument
-if (!$ValidateQueryFolding){ 
-    if ($RunPQSDKTestSuitesSettings.ValidateQueryFolding -eq "True"){
-         $ValidateQueryFolding = $true 
+if (!$ValidateQueryFolding) { 
+    if ($RunPQSDKTestSuitesSettings.ValidateQueryFolding -eq "True") {
+        $ValidateQueryFolding = $true 
     }
 }
 
 #Setting the DetailedResults if not passed as an argument
-if (!$DetailedResults){ 
-    if ($RunPQSDKTestSuitesSettings.DetailedResults -eq "True"){
+if (!$DetailedResults) { 
+    if ($RunPQSDKTestSuitesSettings.DetailedResults -eq "True") {
         $DetailedResults = $true 
     } 
 }
 
 #Setting the JSONResults if not passed as an argument
-if (!$JSONResults){
-    if ($RunPQSDKTestSuitesSettings.JSONResults -eq "True"){
+if (!$JSONResults) {
+    if ($RunPQSDKTestSuitesSettings.JSONResults -eq "True") {
         $JSONResults = $true
     }
 }
@@ -173,7 +179,8 @@ Write-Output ("TestSettingsDirectoryPath: " + $TestSettingsDirectoryPath)
 Write-Output ("TestSettingsList: " + $TestSettingsList)
 Write-Output ("ValidateQueryFolding: " + $ValidateQueryFolding)
 Write-Output ("DetailedResults: " + $DetailedResults)
-Write-Output ("JSONResults: "+ $JSONResults)
+Write-Output ("JSONResults: " + $JSONResults)
+Write-Output ("Pipeline Value: " + $Pipeline) 
 
 $ExtensionParameterQueriesPath = Join-Path -Path (Get-Location) -ChildPath ("ConnectorConfigs\" + (Get-Item $ExtensionPath).Basename + "\ParameterQueries")
 $DiagnosticFolderPath = Join-Path -Path (Get-Location) -ChildPath ("Diagnostics\" + (Get-Item $ExtensionPath).Basename)
@@ -183,28 +190,29 @@ Write-Output ("Note: Please verify the settings above and ensure the following:
 1. Credentials are setup for the extension following the instructions here: https://learn.microsoft.com/en-us/power-query/power-query-sdk-vs-code#set-credential
 2. Parameter query file(s) are updated with the M query to connect to your data source and retrieve the NycTaxiGreen & TaxiZoneLookup tables under: 
 $ExtensionParameterQueriesPath")
-if ($ValidateQueryFolding){ 
-Write-Output ("3. Diagnostics folder path that will be used for query folding verfication: 
+if ($ValidateQueryFolding) { 
+    Write-Output ("3. Diagnostics folder path that will be used for query folding verfication: 
 $DiagnosticFolderPath")
 }
 $PSStyle.Reset
 
-$confirmation = Read-Host "Do you want to proceed? [y/n]" 
-while($confirmation -ne "y")
-{
-    if ($confirmation -eq 'n') {
-        $PSStyle.Foreground.Yellow
-        Write-Host("Please specify the correct settings in RunPQSDKTestSuitesSettings.json or pass them arguments and re-run the script.")
-        $PSStyle.Reset
-        exit
-    }
+if (!$Pipeline) {
     $confirmation = Read-Host "Do you want to proceed? [y/n]"
+    while ($confirmation -ne "y") {
+        if ($confirmation -eq 'n') {
+            $PSStyle.Foreground.Yellow
+            Write-Host("Please specify the correct settings in RunPQSDKTestSuitesSettings.json or pass them arguments and re-run the script.")
+            $PSStyle.Reset
+            exit
+        }
+        $confirmation = Read-Host "Do you want to proceed? [y/n]"
+    }
 }
 
 # Creating the DiagnosticFolderPath if ValidateQueryFolding is set to true
-if ($ValidateQueryFolding){ 
+if ($ValidateQueryFolding) { 
     $DiagnosticFolderPath = Join-Path -Path (Get-Location) -ChildPath ("Diagnostics\" + (Get-Item $ExtensionPath).Basename)
-    if (!(Test-Path $DiagnosticFolderPath)){
+    if (!(Test-Path $DiagnosticFolderPath)) {
         New-Item -ItemType Directory -Force -Path $DiagnosticFolderPath | Out-Null
     }
 }
@@ -218,7 +226,7 @@ class TestResult {
     [string] $TestStatus; 
     [string] $Duration; 
 
-    TestResult([string]$testFolder, [string]$testName, [string]$outputStatus, [string]$testStatus, [string]$duration){
+    TestResult([string]$testFolder, [string]$testName, [string]$outputStatus, [string]$testStatus, [string]$duration) {
         # Constructor to Initialize the Test Result Object
         $this.TestFolder = $testFolder
         $this.TestName = $testName;
@@ -239,7 +247,7 @@ $RawTestResults = @()
 $TestResultsObjects = @()
 
 # Run the compare command for each of the TestSetttings Files
-foreach ($TestSettings in $TestSettingsList){
+foreach ($TestSettings in $TestSettingsList) {
     if ($ValidateQueryFolding) { 
         $RawTestResult = & $PQTestExePath compare -p -e $ExtensionPath -sf $TestSettingsDirectoryPath\$TestSettings -dfp $DiagnosticFolderPath
     }
@@ -250,15 +258,15 @@ foreach ($TestSettings in $TestSettingsList){
     $StringTestResult = $RawTestResult -join " " 
     $TestResultsObject = $StringTestResult | ConvertFrom-Json 
 
-    foreach($Result in $TestResultsObject){
-           $TestResults += [TestResult]::new($Result.Name.Split("\")[-3] + "\" + $Result.Name.Split("\")[-2], $Result.Name.Split("\")[-1], $Result.Output.Status, $Result.Status, (NEW-TIMESPAN -Start $Result.StartTime  -End $Result.EndTime))   
-           $TestCount += 1
-            if($Result.Status -eq "Passed"){
-                $Passed++ 
-            }    
-            else{
-                $Failed++ 
-            }                
+    foreach ($Result in $TestResultsObject) {
+        $TestResults += [TestResult]::new($Result.Name.Split("\")[-3] + "\" + $Result.Name.Split("\")[-2], $Result.Name.Split("\")[-1], $Result.Output.Status, $Result.Status, (NEW-TIMESPAN -Start $Result.StartTime  -End $Result.EndTime))   
+        $TestCount += 1
+        if ($Result.Status -eq "Passed") {
+            $Passed++ 
+        }    
+        else {
+            $Failed++ 
+        }                
     }
 
     $RawTestResults += $RawTestResult
@@ -268,19 +276,17 @@ foreach ($TestSettings in $TestSettingsList){
 # Display the test results
 $TestExecEndTime = Get-Date 
 
-if ($DetailedResults)
-{
+if ($DetailedResults) {
     Write-Output("------------------------------------------------------------------------------------------")
     Write-Output("PQ SDK Test Framework - Test Execution - Detailed Results for Extension: " + $ExtensionPath.Split("\")[-1] )
     Write-Output("------------------------------------------------------------------------------------------")
     $TestResultsObjects
 }
-if ($JSONResults)
-{
+if ($JSONResults) {
     Write-Output("-----------------------------------------------------------------------------------")
     Write-Output("PQ SDK Test Framework - Test Execution - JSON Results for Extension: " + $ExtensionPath.Split("\")[-1] )
     Write-Output("-----------------------------------------------------------------------------------")
-    $RawTestResults
+    $RawTestResults | Set-content results.json
 }
 
 Write-Output("----------------------------------------------------------------------------------------------")
@@ -288,30 +294,34 @@ Write-Output("PQ SDK Test Framework - Test Execution - Test Results Summary for 
 Write-Output("----------------------------------------------------------------------------------------------")
 
 $TestResults  | Format-Table -AutoSize -Property TestFolder, TestName, @{
-    Label = "OutputStatus" 
-    Expression=
+    Label      = "OutputStatus" 
+    Expression =
     { 
         switch ($_.OutputStatus) {
-            { $_ -eq "Passed" } { $color = "$($PSStyle.Foreground.Green)"  }
-            { $_ -eq "Failed" } { $color = "$($PSStyle.Foreground.Red)"    }
-            { $_ -eq "Error"  } { $color = "$($PSStyle.Foreground.Yellow)" }
+            { $_ -eq "Passed" } { $color = "$($PSStyle.Foreground.Green)" }
+            { $_ -eq "Failed" } { $color = "$($PSStyle.Foreground.Red)" }
+            { $_ -eq "Error" } { $color = "$($PSStyle.Foreground.Yellow)" }
+        }
+        "$color$($_.OutputStatus)$($PSStyle.Reset)" 
     }
-    "$color$($_.OutputStatus)$($PSStyle.Reset)" 
-}
 }, @{
-    Label = "TestStatus" 
-    Expression=
+    Label      = "TestStatus" 
+    Expression =
     { 
         switch ($_.TestStatus) {
-            { $_ -eq "Passed" } { $color = "$($PSStyle.Foreground.Green)"  }
-            { $_ -eq "Failed" } { $color = "$($PSStyle.Foreground.Red)"    }
-            { $_ -eq "Error"  } { $color = "$($PSStyle.Foreground.Yellow)" }
+            { $_ -eq "Passed" } { $color = "$($PSStyle.Foreground.Green)" }
+            { $_ -eq "Failed" } { $color = "$($PSStyle.Foreground.Red)" }
+            { $_ -eq "Error" } { $color = "$($PSStyle.Foreground.Yellow)" }
+        }
+        "$color$($_.TestStatus)$($PSStyle.Reset)"
     }
-    "$color$($_.TestStatus)$($PSStyle.Reset)"
-}
 }, 
 Duration
 
 Write-Output("----------------------------------------------------------------------------------------------")
-Write-Output("Total Tests: " + $TestCount + " | Passed: " + $Passed + " | Failed: " + $Failed +  " | Total Duration: " + "{0:dd}d:{0:hh}h:{0:mm}m:{0:ss}s" -f (NEW-TIMESPAN -Start $TestExecStartTime  -End $TestExecEndTime))
+Write-Output("Total Tests: " + $TestCount + " | Passed: " + $Passed + " | Failed: " + $Failed + " | Total Duration: " + "{0:dd}d:{0:hh}h:{0:mm}m:{0:ss}s" -f (NEW-TIMESPAN -Start $TestExecStartTime  -End $TestExecEndTime))
 Write-Output("----------------------------------------------------------------------------------------------")
+
+if ($Failed -gt 0) {
+    exit -1
+}

--- a/testframework/tests/RunPQSDKTestSuites.ps1
+++ b/testframework/tests/RunPQSDKTestSuites.ps1
@@ -3,7 +3,7 @@
        Script: RunPQSDKTestSuites.ps1
        Runs the pre-built PQ/PQOut format tests in Power Query SDK Test Framework using pqtest.exe compare command.
 
-      .DESCRIPTION
+       .DESCRIPTION
        This script will execute the PQ SDK PQ/PQOut tests present under Sanity, Standard & DataSourceSpecific folders. 
        RunPQSDKTestSuitesSettings.json file is used provide configurations need to this script. Please review the template RunPQSDKTestSuitesSettingsTemplate.json for more info.
        Pre-Requisite: Ensure the credentials are setup for your connector following the instructions here: https://learn.microsoft.com/power-query/power-query-sdk-vs-code#set-credential
@@ -60,7 +60,12 @@ param(
 
 # Retrieving the settings for running the TestSuites from the JSON settings file
 if ($RunPQSDKTestSuitesSettingsPath) {
-    $RunPQSDKTestSuitesSettings = Get-Content -Path $RunPQSDKTestSuitesSettingsPath | ConvertFrom-Json
+    if ([string]::IsNullOrEmpty($RunPQSDKTestSuitesSettingsPath) -or !(Test-Path -Path $RunPQSDKTestSuitesSettingsPath)) {
+        $RunPQSDKTestSuitesSettings = Get-Content -Path RunPQSDKTestSuitesSettings.json | ConvertFrom-Json
+    }
+    else {
+        $RunPQSDKTestSuitesSettings = Get-Content -Path $RunPQSDKTestSuitesSettingsPath | ConvertFrom-Json
+    }
 }
 
 # Setting the PQTestExePath from settings object if not passed as an argument
@@ -287,6 +292,7 @@ if ($JSONResults) {
     Write-Output("PQ SDK Test Framework - Test Execution - JSON Results for Extension: " + $ExtensionPath.Split("\")[-1] )
     Write-Output("-----------------------------------------------------------------------------------")
     $RawTestResults | Set-content results.json
+    Write-Output("The file results.json was created with the tests results")
 }
 
 Write-Output("----------------------------------------------------------------------------------------------")


### PR DESCRIPTION
run tests script improvements

- harmonization on the curly brakets placements throughout the script
- refactored tests settings to be a parameter as well
- added pqtest.exe detection to avoid to use too many parameters and simplify usage
- now jsonresults flush the content into a file results.json to be easier to go through
- added error return in case any tests failed, so the test script can fail a pipeline
- added a pipeline parameter to skip user input during pipeline execution